### PR TITLE
feat: 아카이브 팝업 기능 구현 (#69)

### DIFF
--- a/app/src/main/java/com/example/areumdap/RVAdapter/QuestionRVAdapter.kt
+++ b/app/src/main/java/com/example/areumdap/RVAdapter/QuestionRVAdapter.kt
@@ -3,6 +3,7 @@ package com.example.areumdap.RVAdapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.example.areumdap.UI.PopUpDialogFragment
 import com.example.areumdap.databinding.ItemQuestionTaskBinding
 
 class QuestionRVAdapter (private val questionList: ArrayList<String>):
@@ -28,7 +29,22 @@ RecyclerView.Adapter<QuestionRVAdapter.ViewHolder>(){
         }
 
         holder.binding.taskTrashIv.setOnClickListener {
-           removeItem(holder.adapterPosition)
+            val activity = holder.binding.root.context as androidx.fragment.app.FragmentActivity
+
+            val dialog = PopUpDialogFragment.newInstance(
+                title = "저장한 질문을 정말로 삭제하겠어요?\n삭제한 리스트는 되돌릴 수 없어요.",
+                subtitle = "",
+                leftBtn = "이전으로",
+                rightBtn = "삭제하기"
+            )
+
+            dialog.setCallback(object : PopUpDialogFragment.MyDialogCallback{
+                override fun onConfirm(){
+                    removeItem(holder.adapterPosition)
+                }
+            })
+
+            dialog.show(activity.supportFragmentManager, "PopUpDialog")
         }
     }
 

--- a/app/src/main/java/com/example/areumdap/RVAdapter/TaskRVAdapter.kt
+++ b/app/src/main/java/com/example/areumdap/RVAdapter/TaskRVAdapter.kt
@@ -3,6 +3,7 @@ package com.example.areumdap.RVAdapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.example.areumdap.UI.PopUpDialogFragment
 import com.example.areumdap.databinding.ItemArchiveTaskBinding
 
 class TaskRVAdapter(private val questionList: ArrayList<String>):
@@ -31,7 +32,22 @@ class TaskRVAdapter(private val questionList: ArrayList<String>):
         }
 
         holder.binding.taskTrashIv.setOnClickListener {
-            removeItem(holder.adapterPosition)
+            val activity = holder.binding.root.context as androidx.fragment.app.FragmentActivity
+
+            val dialog = PopUpDialogFragment.newInstance(
+                title = "완료한 과제를 정말로 삭제하겠어요?\n삭제한 리스트는 되돌릴 수 없어요.",
+                subtitle = "",
+                leftBtn = "이전으로",
+                rightBtn = "삭제하기"
+            )
+
+            dialog.setCallback(object : PopUpDialogFragment.MyDialogCallback{
+                override fun onConfirm(){
+                    removeItem(holder.adapterPosition)
+                }
+            })
+
+            dialog.show(activity.supportFragmentManager, "PopUpDialog")
         }
     }
 

--- a/app/src/main/java/com/example/areumdap/UI/EmptyTaskFragment.kt
+++ b/app/src/main/java/com/example/areumdap/UI/EmptyTaskFragment.kt
@@ -25,5 +25,13 @@ class EmptyTaskFragment: Fragment() {
         binding.emptyTaskRecommendBtn.setOnClickListener {
             (activity as? MainActivity)?.goToHome()
         }
+
+        /*binding.emptyTaskAiBtn.setOnClickListener {
+            val chatFragment = ChatFragment()
+
+            requireActivity().supportFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, chatFragment)
+                .commit()
+        }*/
     }
 }

--- a/app/src/main/java/com/example/areumdap/UI/PopUpDialogFragment.kt
+++ b/app/src/main/java/com/example/areumdap/UI/PopUpDialogFragment.kt
@@ -1,0 +1,73 @@
+package com.example.areumdap.UI
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.example.areumdap.databinding.ActivityDialogBinding
+
+class PopUpDialogFragment : DialogFragment() {
+    private lateinit var binding : ActivityDialogBinding
+
+    private var callback: MyDialogCallback? = null
+
+    interface MyDialogCallback{
+        fun onConfirm()
+    }
+
+    fun setCallback(callback: MyDialogCallback){
+        this.callback = callback
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+
+        binding = ActivityDialogBinding.inflate(inflater,container,false)
+
+        binding.tvTitle.text = arguments?.getString("title") ?: "제목 없음"
+        binding.tvDesc.text = arguments?.getString("subtitle") ?: ""
+        binding.btnContinue.text = arguments?.getString("btnleft") ?: "이전으로"
+        binding.btnRight.text = arguments?.getString("btnright") ?: "확인"
+
+        binding.btnContinue.setOnClickListener {
+            dismiss()
+        }
+
+        binding.btnRight.setOnClickListener {
+            callback?.onConfirm()
+            dismiss()
+        }
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.apply {
+            setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+            // 다이얼로그의 너비와 높이를 화면에 맞게 재설정
+            val params = attributes
+            params.width = ViewGroup.LayoutParams.MATCH_PARENT
+            params.height = ViewGroup.LayoutParams.WRAP_CONTENT
+            attributes = params
+        }    }
+
+    companion object {
+        fun newInstance(title: String, subtitle: String, leftBtn: String, rightBtn: String): PopUpDialogFragment {
+            return PopUpDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putString("title", title)
+                    putString("subtitle", subtitle)
+                    putString("btnleft", leftBtn)
+                    putString("btnright", rightBtn)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/areumdap/UI/QuestionFragment.kt
+++ b/app/src/main/java/com/example/areumdap/UI/QuestionFragment.kt
@@ -58,7 +58,6 @@ class QuestionFragment : Fragment() {
         val limit = (54 * resources.displayMetrics.density)
 
         val itemTouchHelperCallback = object : ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
-            private var isClamped = false
 
             override fun onMove(
                 recyclerView: RecyclerView,

--- a/app/src/main/res/layout/activity_dialog.xml
+++ b/app/src/main/res/layout/activity_dialog.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#80000000">
+    android:background="@android:color/transparent">
 
     <LinearLayout
         android:id="@+id/dialog_ll"
@@ -29,8 +29,9 @@
             android:layout_height="wrap_content"
             android:text="대화를 종료하시겠어요?"
             android:textColor="#000000"
+            android:lineSpacingExtra="21dp"
             android:textSize="18sp"
-            android:textStyle="bold"
+            android:textStyle="normal"
             android:gravity="center"
             android:layout_marginBottom="8dp"/>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,6 +16,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
+    <include
+        android:id="@+id/character_tool_bar"
+        layout="@layout/layout_toolbar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        />
+
     <!-- 바텀네비게이션 -->
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/main_bnv"

--- a/app/src/main/res/layout/fragment_question.xml
+++ b/app/src/main/res/layout/fragment_question.xml
@@ -41,7 +41,7 @@
     <Spinner
         android:id="@+id/question_sp"
         android:layout_width="78dp"
-        android:layout_height="24dp"
+        android:layout_height="36dp"
         android:layout_alignParentEnd="true"
         android:background="@drawable/bg_spinner"
         android:popupBackground="@drawable/bg_spinner_dropdown"


### PR DESCRIPTION
- 제목 : feat: 아카이브 팝업 기능 구현(#69)

## 📌내용
- 아카이브에서 완료한 과제와 저장한 질문 페이지에서 아이템을 삭제하기전에 팝업을 띄우게 했습니다.

## 테스트
- [ ] 빌드/실행 확인
- [ ] 주요 동작 확인

## 리뷰 포인트
- 팝업이 잘 나오는지 확인해주세용

## 관련 이슈
- 이슈 번호 : # 69


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 항목 삭제 시 확인 팝업이 나타나도록 추가되었습니다. 삭제를 확인하면 항목이 제거됩니다.

* **UI/Style**
  * 상단 도구 모음이 추가되었습니다.
  * 대화 상자 배경 및 텍스트 스타일이 개선되었습니다.
  * 일부 UI 요소의 크기가 조정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->