### PR TITLE
refactor: 저장한 질문 api 수정(#111)

### DIFF
--- a/app/src/main/java/com/example/areumdap/RVAdapter/QuestionRVAdapter.kt
+++ b/app/src/main/java/com/example/areumdap/RVAdapter/QuestionRVAdapter.kt
@@ -10,6 +10,9 @@ import com.example.areumdap.databinding.ItemQuestionTaskBinding
 class QuestionRVAdapter (private val questionList: ArrayList<QuestionItem>):
 RecyclerView.Adapter<QuestionRVAdapter.ViewHolder>(){
 
+    var itemDeleteListener: ((Int) -> Unit)? = null
+    var itemClickListener: ((QuestionItem) -> Unit)? = null
+
     inner class ViewHolder(val binding: ItemQuestionTaskBinding): RecyclerView.ViewHolder(binding.root)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder{
@@ -21,12 +24,19 @@ RecyclerView.Adapter<QuestionRVAdapter.ViewHolder>(){
         val item = questionList[position]
         // 테스트용
         holder.binding.itemQuestionTaskTv.text = item.content
+        holder.binding.taskCardView.translationX = 0f
+
+        // 태그별 스타일 적용 (tag 필드가 QuestionItem에 있다고 가정)
+        // QuestionItem에 tag 필드가 없으면 추가해야 함. TaskData.kt 확인 필요.
+        // 일단 TaskRVAdapter와 동일한 로직 적용 시도.
+        applyTagStyle(holder, item.tag)
 
         holder.binding.taskCardView.setOnClickListener {
             if(it.translationX < 0f){
                 it.animate().translationX(0f).setDuration(200).start()
             } else{
-                // 닫혀있을 때 클릭 철
+                // 닫혀있을 때 클릭 처리
+                itemClickListener?.invoke(item)
             }
         }
 
@@ -44,7 +54,7 @@ RecyclerView.Adapter<QuestionRVAdapter.ViewHolder>(){
                 override fun onConfirm(){
                     val position = holder.adapterPosition
                     if (position != RecyclerView.NO_POSITION) {
-                        removeItem(position)
+                        itemDeleteListener?.invoke(item.userQuestionId)
                     }
                 }
             })
@@ -54,16 +64,61 @@ RecyclerView.Adapter<QuestionRVAdapter.ViewHolder>(){
     }
 
     override fun getItemCount(): Int = questionList.size
-    //아이템 삭제
+    //아이템 삭제 대신 리스너 호출로 변경됨
     fun removeItem(position: Int){
-        questionList.removeAt(position)
-        notifyItemRemoved(position)
-        notifyItemRangeChanged(position, questionList.size)
+        // viewModel에서 삭제 후 updateData가 호출되므로 여기서는 아무것도 안함
     }
 
     fun updateData(newData: List<QuestionItem>) {
         questionList.clear()
         questionList.addAll(newData)
         notifyDataSetChanged()
+    }
+    private fun applyTagStyle(holder: ViewHolder, tag: String) {
+        val context = holder.binding.root.context
+        val binding = holder.binding
+
+        var textColorRes = com.example.areumdap.R.color.black
+        var iconRes = com.example.areumdap.R.drawable.ic_reflection // 기본 아이콘
+
+        when (tag) {
+            "CAREER" -> {
+                textColorRes = com.example.areumdap.R.color.career2
+                iconRes = com.example.areumdap.R.drawable.ic_career
+            }
+            "RELATIONSHIP" -> {
+                textColorRes = com.example.areumdap.R.color.relationship2
+                iconRes = com.example.areumdap.R.drawable.ic_relationship
+            }
+            "SELF_REFLECTION" -> {
+                textColorRes = com.example.areumdap.R.color.reflection2
+                iconRes = com.example.areumdap.R.drawable.ic_reflection
+            }
+            "EMOTION" -> {
+                textColorRes = com.example.areumdap.R.color.emotion2
+                iconRes = com.example.areumdap.R.drawable.ic_emotion
+            }
+            "GROWTH" -> {
+                textColorRes = com.example.areumdap.R.color.growth2
+                iconRes = com.example.areumdap.R.drawable.ic_growth
+            }
+            "ETC" -> {
+                textColorRes = com.example.areumdap.R.color.etc2
+                iconRes = com.example.areumdap.R.drawable.ic_etc
+            }
+            else -> {
+                textColorRes = com.example.areumdap.R.color.etc2
+                iconRes = com.example.areumdap.R.drawable.ic_etc
+            }
+        }
+
+        // 배경색 적용 코드 제거됨
+
+        // 텍스트 색상 적용
+        val textColor = androidx.core.content.ContextCompat.getColor(context, textColorRes)
+        binding.itemQuestionTaskTv.setTextColor(textColor)
+        
+        // 아이콘 적용
+        binding.itemQuestionTaskIv.setImageResource(iconRes)
     }
 }

--- a/app/src/main/java/com/example/areumdap/RVAdapter/TaskRVAdapter.kt
+++ b/app/src/main/java/com/example/areumdap/RVAdapter/TaskRVAdapter.kt
@@ -11,6 +11,8 @@ class TaskRVAdapter(private val questionList: ArrayList<MissionItem>):
     RecyclerView.Adapter<TaskRVAdapter.ViewHolder>(){
 
     var itemClickListener: ((MissionItem) -> Unit)? = null
+    var itemDeleteListener: ((Int) -> Unit)? = null
+
     inner class ViewHolder(val binding: ItemArchiveTaskBinding): RecyclerView.ViewHolder(binding.root)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder{
@@ -18,10 +20,17 @@ class TaskRVAdapter(private val questionList: ArrayList<MissionItem>):
         return ViewHolder(binding)
     }
 
+
+
+    // ... (omitted)
+
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = questionList[position]
 
         with(holder.binding){
+            // 뷰홀더 재사용 시 스와이프 상태 초기화
+            taskCardView.translationX = 0f
+
             // 질문 제목 반영
             itemArchiveTaskTv.text = item.title
 
@@ -30,6 +39,9 @@ class TaskRVAdapter(private val questionList: ArrayList<MissionItem>):
 
             // 3. 경험치 반영 (reward 필드 사용)
             itemArchiveXpTv.text = item.reward.toString()
+
+            // 4. 태그별 스타일 적용
+            applyTagStyle(holder, item.tag)
 
             // 카드 클릭 리스너 (스와이프 상태 확인 및 상세 페이지 이동)
             taskCardView.setOnClickListener {
@@ -53,7 +65,7 @@ class TaskRVAdapter(private val questionList: ArrayList<MissionItem>):
 
                 dialog.setCallback(object : PopUpDialogFragment.MyDialogCallback{
                     override fun onConfirm(){
-                        removeItem(holder.adapterPosition)
+                        itemDeleteListener?.invoke(item.missionId)
                     }
                 })
 
@@ -65,11 +77,7 @@ class TaskRVAdapter(private val questionList: ArrayList<MissionItem>):
     override fun getItemCount(): Int = questionList.size
 
     fun removeItem(position: Int) {
-        if (position != RecyclerView.NO_POSITION) {
-            questionList.removeAt(position)
-            notifyItemRemoved(position)
-            notifyItemRangeChanged(position, questionList.size)
-        }
+         // viewModel에서 삭제 후 updateData가 호출되므로 여기서는 아무것도 안함
     }
 
     fun updateData(newData: List<MissionItem>) {
@@ -81,21 +89,67 @@ class TaskRVAdapter(private val questionList: ArrayList<MissionItem>):
     private fun formatDateWithDay(dateString: String): String {
         return try {
             // 1. 서버에서 오는 형식 (밀리초 .SSS와 Z 포함)
-            // Z는 시간대를 나타내므로 따옴표 없이 사용합니다.
             val inputFormat = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.getDefault())
-            // 서버 시간이 UTC 기준이므로 포맷터에게 이를 알려줍니다.
             inputFormat.timeZone = java.util.TimeZone.getTimeZone("UTC")
 
             val date = inputFormat.parse(dateString)
 
             // 2. 출력할 형식: 2026.02.02 (월)
-            // Locale.KOREA를 설정해야 '월', '화' 같은 한글 요일이 나옵니다.
             val outputFormat = java.text.SimpleDateFormat("yyyy.MM.dd (E)", java.util.Locale.KOREA)
 
-            date?.let { outputFormat.format(it) } ?: dateString
+            date?.let {
+                outputFormat.format(it)
+            } ?: dateString
+
         } catch (e: Exception) {
-            // 변환 실패 시 원본 문자열의 날짜 부분만이라도 출력
             dateString.split("T")[0].replace("-", ".")
         }
+    }
+
+    private fun applyTagStyle(holder: ViewHolder, tag: String) {
+        val context = holder.binding.root.context
+        val binding = holder.binding
+
+        var textColorRes = com.example.areumdap.R.color.black
+        var iconRes = com.example.areumdap.R.drawable.ic_reflection // 기본 아이콘
+
+        when (tag) {
+            "CAREER" -> {
+                textColorRes = com.example.areumdap.R.color.career2
+                iconRes = com.example.areumdap.R.drawable.ic_career
+            }
+            "RELATIONSHIP" -> {
+                textColorRes = com.example.areumdap.R.color.relationship2
+                iconRes = com.example.areumdap.R.drawable.ic_relationship
+            }
+            "SELF_REFLECTION" -> {
+                textColorRes = com.example.areumdap.R.color.reflection2
+                iconRes = com.example.areumdap.R.drawable.ic_reflection
+            }
+            "EMOTION" -> {
+                textColorRes = com.example.areumdap.R.color.emotion2
+                iconRes = com.example.areumdap.R.drawable.ic_emotion
+            }
+            "GROWTH" -> {
+                textColorRes = com.example.areumdap.R.color.growth2
+                iconRes = com.example.areumdap.R.drawable.ic_growth
+            }
+            "ETC" -> {
+                textColorRes = com.example.areumdap.R.color.etc2
+                iconRes = com.example.areumdap.R.drawable.ic_etc
+            }
+            else -> {
+                textColorRes = com.example.areumdap.R.color.etc2
+                iconRes = com.example.areumdap.R.drawable.ic_etc
+            }
+        }
+
+
+        // 텍스트 색상 적용
+        val textColor = androidx.core.content.ContextCompat.getColor(context, textColorRes)
+        binding.itemArchiveTaskTv.setTextColor(textColor)
+
+        // 아이콘 적용
+        binding.itemArchiveTaskIv.setImageResource(iconRes)
     }
 }

--- a/app/src/main/java/com/example/areumdap/Task/QuestionFragment.kt
+++ b/app/src/main/java/com/example/areumdap/Task/QuestionFragment.kt
@@ -52,12 +52,13 @@ class QuestionFragment : Fragment() {
         // 저장한 질문 목록 관찰
         viewModel.savedQuestions.observe(viewLifecycleOwner) { questions ->
             questions?.let{
-                binding.questionTotalTv.text = "${it.size}"
-
                 questionRVAdapter.updateData(it)
             }
         }
 
+        viewModel.questionTotalCount.observe(viewLifecycleOwner){ total ->
+            binding.questionTotalTv.text = "$total"
+        }
         // 에러 메시지 관찰
         viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
             errorMsg?.let {
@@ -68,6 +69,22 @@ class QuestionFragment : Fragment() {
 
     private fun setupRecyclerView() {
         questionRVAdapter = QuestionRVAdapter(arrayListOf())
+
+        questionRVAdapter.itemDeleteListener = { userQuestionId ->
+            viewModel.deleteSavedQuestion(userQuestionId)
+        }
+
+        questionRVAdapter.itemClickListener = { questionItem ->
+            val chatFragment = com.example.areumdap.UI.Chat.ChatFragment()
+            val bundle = Bundle()
+            bundle.putString("prefill_question", questionItem.content)
+            chatFragment.arguments = bundle
+
+            requireActivity().supportFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, chatFragment)
+                .addToBackStack(null)
+                .commit()
+        }
 
         binding.questionListRv.apply {
             adapter = questionRVAdapter

--- a/app/src/main/java/com/example/areumdap/Task/TaskData.kt
+++ b/app/src/main/java/com/example/areumdap/Task/TaskData.kt
@@ -27,6 +27,9 @@ data class CompletedMissionsResponse(
     @SerializedName("missions")
     val missions: List<MissionItem>,
 
+    @SerializedName("totalCount")
+    val totalCount: Int,
+
     @SerializedName("nextCursorTime")
     val nextCursorTime: String?,
 
@@ -85,6 +88,9 @@ data class SavedQuestionsResponse(
 )
 
 data class QuestionData(
+    @SerializedName("totalCount")
+    val totalCount: Int,
+
     @SerializedName("questions")
     val questions: List<QuestionItem>,
 

--- a/app/src/main/java/com/example/areumdap/Task/TaskFragment.kt
+++ b/app/src/main/java/com/example/areumdap/Task/TaskFragment.kt
@@ -108,6 +108,10 @@ class TaskFragment : Fragment() {
                 .commit()
         }
 
+        taskRVAdapter.itemDeleteListener = { missionId ->
+            viewModel.deleteCompletedMission(missionId)
+        }
+
         binding.taskListRv.apply {
             adapter = taskRVAdapter
             layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
@@ -123,9 +127,13 @@ class TaskFragment : Fragment() {
                 Log.d("FRAGMENT_OBSERVER", "데이터 전달받음: ${it.size}개")
 
                 binding.taskFinishTv.text = "${it.size}"
-                binding.taskTotalTv.text = "${it.size}"
                 taskRVAdapter.updateData(it)
             }
+        }
+
+        viewModel.totalMissionCount.observe(viewLifecycleOwner) { total ->
+            Log.d("TOTAL_COUNT", "서버에서 받은 전체 개수: $total")
+            binding.taskTotalTv.text = "$total"
         }
 
         // 로딩 상태 관찰

--- a/app/src/main/res/layout/fragment_question.xml
+++ b/app/src/main/res/layout/fragment_question.xml
@@ -57,10 +57,10 @@
         android:id="@+id/question_list_rv"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:orientation="horizontal"
         app:layout_constraintStart_toStartOf="@+id/question_number_ll"
         app:layout_constraintEnd_toEndOf="@+id/question_sp"
         app:layout_constraintTop_toBottomOf="@+id/question_number_ll"
+        app:layout_constraintBottom_toBottomOf="parent"
         tools:listitem="@layout/item_question_task"
         android:layout_marginTop="38dp"/>
 

--- a/app/src/main/res/layout/fragment_task.xml
+++ b/app/src/main/res/layout/fragment_task.xml
@@ -70,10 +70,10 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginTop="38dp"
-        android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="@+id/task_sp"
         app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="@+id/task_number_ll"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/task_number_ll"
         tools:listitem="@layout/item_archive_task" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_question_task.xml
+++ b/app/src/main/res/layout/item_question_task.xml
@@ -64,7 +64,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginTop="42dp"
-            android:layout_marginEnd="10dp"
+            android:layout_marginEnd="20dp"
             android:layout_width="7.5dp"
             android:layout_height="15dp"/>
 


### PR DESCRIPTION
- 제목 : refactor: 저장한 질문 api 수정(#111)

## 📌내용
- 저장한 질문 api를 모든 작업을 완료했습니다. 아이템을 삭제하면 전체 개수도 줄어들고 tag값에 맞게 색과 이미지 변경하게 하였습니다. 아이템을 누르면 대화로 넘어가게 했습니다.

## 테스트
- [ ] 빌드/실행 확인
- [ ] 주요 동작 확인



## 리뷰 포인트
- 잘 작동하는지 봐주세요 ㅎㅎ

## 관련 이슈
- 이슈 번호 : # 111


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 작업 및 질문 항목의 삭제 기능 추가
  * 질문 클릭 시 채팅 기능으로 직접 연결

* **버그 수정**
  * 작업 및 질문 총 개수 표시 정확도 개선

* **스타일**
  * 태그 기반 항목 스타일링 강화
  * UI 레이아웃 및 여백 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->