### PR TITLE
feat: 스플래시 액티비티 매니페스트 설정 및 시작 화면 지정 (#114)

### DIFF
--- a/app/src/main/java/com/example/areumdap/UI/SplashActivity.kt
+++ b/app/src/main/java/com/example/areumdap/UI/SplashActivity.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.example.areumdap.Network.AuthRepository
 import com.example.areumdap.Network.TokenManager
+import com.example.areumdap.R
 import com.example.areumdap.UI.Onboarding.OnboardingActivity
 import com.example.areumdap.UI.auth.LoginActivity
 import kotlinx.coroutines.launch
@@ -19,7 +20,7 @@ class SplashActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // 스플래시 화면 레이아웃이 있다면 설정 (없다면 생략 가능하거나 로고만 있는 xml 생성)
-        // setContentView(R.layout.activity_splash)
+        setContentView(R.layout.activity_splash)
 
         TokenManager.init(this)
 

--- a/app/src/main/res/drawable/splash_background.xml
+++ b/app/src/main/res/drawable/splash_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- 배경색 -->
+    <item android:drawable="@color/background2" />
+
+    <!-- 로고 (중앙에) -->
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/ic_splash_logo" />
+    </item>
+</layer-list>


### PR DESCRIPTION
## 📌내용
- 스플래시 액티비티 매니페스트 설정 및 시작 화면 지정

## 테스트
- [ ] 빌드/실행 확인
- [ ] 주요 동작 확인

## 스크린샷 (UI 변경 시)
| Before | After |
|---|---|
|  |  |

## 리뷰 포인트
-

## 관련 이슈
- 이슈 번호 : # 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **버그 수정**
  * 스플래시 화면이 앱 시작 시 정상적으로 표시됩니다.

* **사용자 인터페이스**
  * 스플래시 화면에 배경색과 중앙 정렬된 로고가 포함된 새로운 시각적 디자인이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->