### PR TITLE
bug: 저장한 질문 아이템 오류(#142)

### DIFF
--- a/app/src/main/java/com/example/areumdap/RVAdapter/QuestionRVAdapter.kt
+++ b/app/src/main/java/com/example/areumdap/RVAdapter/QuestionRVAdapter.kt
@@ -22,9 +22,12 @@ RecyclerView.Adapter<QuestionRVAdapter.ViewHolder>(){
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = questionList[position]
-        holder.binding.itemQuestionTaskTv.text = item.content
+        
+        // 질문 내용 바인딩 (아래쪽 텍스트)
+        holder.binding.itemQuestionContentTv.text = item.content
         holder.binding.taskCardView.translationX = 0f
 
+        // 태그 텍스트 및 스타일 적용 (위쪽 텍스트)
         applyTagStyle(holder, item.tag)
 
         holder.binding.taskCardView.setOnClickListener {
@@ -114,5 +117,17 @@ RecyclerView.Adapter<QuestionRVAdapter.ViewHolder>(){
         
         // 아이콘 적용
         binding.itemQuestionTaskIv.setImageResource(iconRes)
+        
+        // 태그 한글명 변환 및 적용
+        val tagName = when (tag) {
+            "CAREER" -> "진로"
+            "RELATIONSHIP", "RELATION" -> "관계"
+            "REFLECTION", "SELF_REFLECTION" -> "자기성찰"
+            "EMOTION" -> "감정"
+            "GROWTH" -> "성장"
+            "ETC", "OTHER", "OTHERS", "ELSE" -> "기타"
+            else -> "기타"
+        }
+        binding.itemQuestionTaskTv.text = tagName
     }
 }

--- a/app/src/main/java/com/example/areumdap/UI/Character/CharacterApiService.kt
+++ b/app/src/main/java/com/example/areumdap/UI/Character/CharacterApiService.kt
@@ -16,4 +16,7 @@ interface CharacterApiService {
 
     @GET("api/characters/me")
     suspend fun getMycharacter(): Response<BaseResponse<CharacterLevelUpResponse>>
+
+    @POST("api/characters/history/summary")
+    suspend fun postCharacterHistorySummary(): Response<BaseResponse<String>>
 }

--- a/app/src/main/java/com/example/areumdap/UI/Character/CharacterViewModel.kt
+++ b/app/src/main/java/com/example/areumdap/UI/Character/CharacterViewModel.kt
@@ -63,6 +63,19 @@ class CharacterViewModel(private val apiService: CharacterApiService) : ViewMode
                     Log.d("DEBUG_API", "fetchCharacterLevel Body: $body")
                     if (body?.data != null) {
                         _characterLevel.value = body.data
+                        
+                        // 레벨업/정보 갱신 성공 시 히스토리 요약 업데이트 요청
+                        try {
+                            val summaryResponse = apiService.postCharacterHistorySummary()
+                            if (summaryResponse.isSuccessful) {
+                                Log.d("DEBUG_API", "History Summary Updated")
+                            } else {
+                                Log.e("DEBUG_API", "History Summary Update Failed: ${summaryResponse.code()}")
+                            }
+                        } catch (e: Exception) {
+                            Log.e("DEBUG_API", "History Summary Update Exception", e)
+                        }
+                        
                     } else {
                         Log.e("DEBUG_API", "fetchCharacterLevel Body Data is NULL")
                     }

--- a/app/src/main/res/layout/item_archive_task.xml
+++ b/app/src/main/res/layout/item_archive_task.xml
@@ -38,6 +38,7 @@
         <TextView
             android:id="@+id/item_archive_task_tv"
             android:text="자기 성찰"
+            style="@style/item_tag_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:layout_constraintStart_toEndOf="@id/item_archive_task_iv"

--- a/app/src/main/res/layout/item_question_task.xml
+++ b/app/src/main/res/layout/item_question_task.xml
@@ -49,7 +49,7 @@
 
         <TextView
             style="@style/TA_Body2"
-            android:text="나에게 가장 중요한 가치는 무엇인가요?"
+            android:id="@+id/item_question_content_tv"
             android:textColor="@color/black"
             android:layout_width="280dp"
             android:layout_height="20dp"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -64,6 +64,11 @@
         <item name="android:textColor">#666666</item>
     </style>
 
+    <style name="item_tag_tv">
+        <item name="android:textSize">14sp</item>
+        <item name="android:textStyle">normal</item>
+    </style>
+
     <style name="character_task">
         <item name="android:textSize">14sp</item>
         <item name="android:textStyle">normal</item>


### PR DESCRIPTION
- 제목 : bug: 저장한 질문 아이템 오류(#142)
## 📌내용
- 아카이브 페이지에서 저정한 질문 아이템에서 tag가 나와야할 곳에 저장한 질문 내용이 나와서 수정했습니다.

## 테스트
- [ ] 빌드/실행 확인
- [ ] 주요 동작 확인

## 스크린샷 (UI 변경 시)
| Before | After |
|---|---|
|  | 
<img width="318" height="680" alt="스크린샷 2026-02-08 01 56 59" src="https://github.com/user-attachments/assets/31ce75cf-0aaa-4d89-9b57-37a8244fed93" />
 |

## 리뷰 포인트
- 잘 변경되었는지 봐주세요

## 관련 이슈
- 이슈 번호 : # 142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캐릭터 히스토리 요약 업데이트 기능 추가
  * 질문 항목에 한글 태그 이름 표시 기능 추가

* **스타일**
  * 태그 텍스트 스타일 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->