### PR TITLE
refactor: 온보딩 진행바 수정(#185)

### DIFF
--- a/app/src/main/java/com/example/areumdap/UI/Onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/example/areumdap/UI/Onboarding/OnboardingActivity.kt
@@ -288,10 +288,12 @@ class OnboardingActivity : AppCompatActivity() {
      */
     private fun calculateDisplayStep(step: OnboardingStep): Int {
         return when (step) {
-            OnboardingStep.INFO, OnboardingStep.FINAL -> {
+            OnboardingStep.INFO -> {
                 val infoTextStep = InfoTextStep.fromValue(viewModel.infoTextStep.value ?: 0)
                 infoTextStep.displayProgress
             }
+
+            OnboardingStep.FINAL -> OnboardingStep.FINAL.displayProgress
 
             else -> step.displayProgress
         }

--- a/app/src/main/java/com/example/areumdap/UI/Onboarding/OnboardingInfoFragment.kt
+++ b/app/src/main/java/com/example/areumdap/UI/Onboarding/OnboardingInfoFragment.kt
@@ -200,21 +200,24 @@ class OnboardingInfoFragment: Fragment() {
                 Log.d("CharacterAPI", "응답 코드: ${response.code()}")
                 Log.d("CharacterAPI", "응답 성공 여부: ${response.isSuccessful}")
 
-                if (response.isSuccessful) {
-                    saveCharacterInfo(characterId, imageUrl)
-                    characterViewModel.resetUiState()
-                    viewModel.infoTextStep.value = -1
-                    hideLoading()
-                    (activity as? OnboardingActivity)?.navigateToMain()
-                } else {
-                    hideLoading()
-                    showError("온보딩 저장에 실패했습니다.")
-                    characterViewModel.resetUiState()
+                if (!response.isSuccessful) {
+                    Log.e("CharacterAPI", "온보딩 저장 응답 실패 (코드: ${response.code()}), 메인으로 이동 계속 진행")
                 }
-            } catch (e: Exception) {
-                hideLoading()
-                Log.e("CharacterAPI", "예외 발생", e)
+
+                // 캐릭터는 이미 생성 완료되었으므로 온보딩 저장 성공/실패 무관하게 메인으로 이동
+                saveCharacterInfo(characterId, imageUrl)
                 characterViewModel.resetUiState()
+                viewModel.infoTextStep.value = -1
+                hideLoading()
+                (activity as? OnboardingActivity)?.navigateToMain()
+            } catch (e: Exception) {
+                Log.e("CharacterAPI", "예외 발생", e)
+                // 예외 발생해도 캐릭터는 이미 생성되었으므로 메인으로 이동
+                saveCharacterInfo(characterId, imageUrl)
+                characterViewModel.resetUiState()
+                viewModel.infoTextStep.value = -1
+                hideLoading()
+                (activity as? OnboardingActivity)?.navigateToMain()
             }
         }
     }


### PR DESCRIPTION
## 📌내용
- 온보딩 완료 후 메인으로 이동 시 진행바 숫자가 3/5로 뜸

## 테스트
- [ ] 빌드/실행 확인
- [ ] 주요 동작 확인

## 스크린샷 (UI 변경 시)
| Before | After |
|---|---|
|  |  |

## 리뷰 포인트
-

## 관련 이슈
- 이슈 번호 : #185 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **온보딩 저장 흐름 개선** - 저장 성공 여부와 관계없이 메인 화면으로 이동하도록 수정
* **온보딩 진행 상황 표시 정확성 향상** - 최종 단계의 진행 상황 표시가 독립적으로 작동하도록 개선
* **오류 처리 강화** - 예외 발생 시에도 UI 상태가 올바르게 초기화되고 네비게이션이 정상적으로 진행

<!-- end of auto-generated comment: release notes by coderabbit.ai -->