### PR TITLE
feat: 키워드 선택 개수 3개로 제한 (#208)

### DIFF
--- a/app/src/main/java/com/example/areumdap/UI/Onboarding/OnboardingKeywordFragment.kt
+++ b/app/src/main/java/com/example/areumdap/UI/Onboarding/OnboardingKeywordFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -123,14 +124,23 @@ class OnboardingKeywordFragment : Fragment(){
             // 초기 상태: 미선택 (흰색 배경 + 테두리)
             applyUnselectedStyle()
 
-            setOnCheckedChangeListener { _, isChecked ->
+            setOnCheckedChangeListener { chip, isChecked ->
                 if (isChecked) {
-                    applySelectedStyle()
+                    val success = viewModel.toggleKeyword(keyword)
+                    if (success) {
+                        applySelectedStyle()
+                    } else {
+                        // 3개 초과 → 선택 되돌리기 + 토스트
+                        chip.isChecked = false
+                        Toast.makeText(requireContext(), "키워드는 3개까지만 선택 가능합니다", Toast.LENGTH_SHORT).show()
+                        return@setOnCheckedChangeListener
+                    }
                 } else {
+                    viewModel.toggleKeyword(keyword)
                     applyUnselectedStyle()
                 }
 
-                handleKeywordSelection(keyword, isChecked)
+                updateButtonState()
             }
 
             if (viewModel.selectedKeywords.value?.contains(keyword) == true) {
@@ -157,11 +167,6 @@ class OnboardingKeywordFragment : Fragment(){
         chipStrokeWidth = 1f * resources.displayMetrics.density
     }
 
-
-    private fun handleKeywordSelection(keyword: String, isChecked: Boolean) {
-        viewModel.toggleKeyword(keyword)
-        updateButtonState()
-    }
 
     // 최소 1개 이상의 키워드가 선택되어야 버튼 활성화
     private fun updateButtonState() {

--- a/app/src/main/java/com/example/areumdap/UI/Onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/example/areumdap/UI/Onboarding/OnboardingViewModel.kt
@@ -29,16 +29,27 @@ class OnboardingViewModel : ViewModel() {
     // 4단계: 닉네임
     val nickname = MutableLiveData<String>("")
 
-    fun toggleKeyword(keyword: String) {
+    companion object {
+        const val MAX_KEYWORD_COUNT = 3
+    }
+
+    /**
+     * @return true: 토글 성공, false: 3개 초과로 추가 실패
+     */
+    fun toggleKeyword(keyword: String): Boolean {
         val current = selectedKeywords.value ?: mutableListOf()
         if (current.contains(keyword)) {
             current.remove(keyword)
         } else {
+            if (current.size >= MAX_KEYWORD_COUNT) {
+                return false // 3개 초과 선택 불가
+            }
             current.add(keyword)
         }
         selectedKeywords.value = current
 
         // 키워드가 하나라도 있으면 버튼 활성화
         isKeywordSelected.value = current.isNotEmpty()
+        return true
     }
 }


### PR DESCRIPTION
## 📌내용
- 키워드 선택 개수 3개로 제한
- 3개 이상 선택 시 토스트 메시지

## 테스트
- [x] 빌드/실행 확인
- [x] 주요 동작 확인

## 스크린샷 (UI 변경 시)
| Before | After |
|---|---|
|  |  |

## 리뷰 포인트
-

## 관련 이슈
- 이슈 번호 : #208 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 키워드 선택 제한: 최대 선택 가능한 키워드 수에 도달하면 추가 선택을 방지하고 사용자 피드백을 제공합니다.

* **개선 사항**
  * 키워드 선택/해제 프로세스 개선: 더욱 안정적인 상태 관리 및 실시간 버튼 상태 업데이트를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->