### PR TITLE
bug : 채팅 종료 후 대화 이어가기 안되는 버그 수정 (#212)

### DIFF
--- a/app/src/main/java/com/example/areumdap/UI/Chat/ChatFragment.kt
+++ b/app/src/main/java/com/example/areumdap/UI/Chat/ChatFragment.kt
@@ -231,6 +231,10 @@ class ChatFragment : Fragment(R.layout.fragment_chat) {
                         .commit()
                 }
             }
+
+            override fun onCancel() {
+                vm.resumeChatSession()
+            }
         })
 
         dialog.show(parentFragmentManager, "chat_end_dialog")

--- a/app/src/main/java/com/example/areumdap/UI/Chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/areumdap/UI/Chat/ChatViewModel.kt
@@ -74,6 +74,10 @@ class ChatViewModel(
         sessionEnded = false
     }
 
+    fun resumeChatSession() {
+        sessionEnded = false
+    }
+
 
 
     //    오늘의 추천 질문

--- a/app/src/main/java/com/example/areumdap/UI/auth/PopUpDialogFragment.kt
+++ b/app/src/main/java/com/example/areumdap/UI/auth/PopUpDialogFragment.kt
@@ -15,7 +15,8 @@ class PopUpDialogFragment : DialogFragment() {
     private var callback: MyDialogCallback? = null
 
     interface MyDialogCallback{
-        fun onConfirm()
+        fun onConfirm() {}
+        fun onCancel() {}
     }
 
     fun setCallback(callback: MyDialogCallback){
@@ -43,6 +44,7 @@ class PopUpDialogFragment : DialogFragment() {
         binding.btnRight.text = arguments?.getString("btnright") ?: "확인"
 
         binding.btnContinue.setOnClickListener {
+            callback?.onCancel()
             dismiss()
         }
 

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -157,7 +157,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="이름 변경"
+                    android:text="닉네임"
                     android:textColor="#1A1A1A"
                     android:textSize="15sp" />
 


### PR DESCRIPTION
## 📌내용
- 대화 이어가기 버튼 클릭 시 sessionEnded를 false로 바꾸는 resumeChatSession() 함수 호출

## 테스트
- [x] 빌드/실행 확인
- [x] 주요 동작 확인

## 스크린샷 (UI 변경 시)
| Before | After |
|---|---|
|  | 
<img width="344" height="262" alt="image" src="https://github.com/user-attachments/assets/40660550-fb5f-4af1-a437-e8b4a8dcf7d5" />
 |

## 리뷰 포인트
-

## 관련 이슈
- 이슈 번호 : #212  
