### PR TITLE
fix: 온보딩 키워드 선택 수정 (#266)

### DIFF
--- a/app/src/main/java/com/example/areumdap/UI/Onboarding/OnboardingKeywordFragment.kt
+++ b/app/src/main/java/com/example/areumdap/UI/Onboarding/OnboardingKeywordFragment.kt
@@ -48,6 +48,7 @@ class OnboardingKeywordFragment : Fragment(){
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        viewModel.selectedKeywords.value = mutableListOf()
         viewModel.isKeywordSelected.value = false
         viewModel.isDirectInput.value = false
 


### PR DESCRIPTION
## 📌내용
- 계절 다시고르고 키워드 선택하면 키워드 3개 안골라도 3개까지만 하란 메세지 뜨는 버그 수정

## 테스트
- [ ] 빌드/실행 확인
- [ ] 주요 동작 확인

## 스크린샷 (UI 변경 시)
| Before | After |
|---|---|
|  |  |

## 리뷰 포인트
-

## 관련 이슈
- 이슈 번호 : #266


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 온보딩 단계에서 키워드 선택 상태가 올바르게 초기화되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->